### PR TITLE
Fix currently failing linting

### DIFF
--- a/src/crystallography_bluesky/common/utils/beamline_client.py
+++ b/src/crystallography_bluesky/common/utils/beamline_client.py
@@ -53,7 +53,7 @@ class BlueAPIPythonClient(BlueapiClient):
         # response = self.create_and_start_task(task)
         response = self.run_task(task, on_event=on_event, timeout=None)
         print(response)
-        if response.task_status is not None and not response.task_status.task_failed:
+        if response.result is not None and not response.task_failed:
             print("Plan Succeeded")
-        elif response.task_status is not None and response.task_status.task_failed:
+        elif response.result is not None and response.task_failed:
             print("Plan Failed")

--- a/src/crystallography_bluesky/i11/plans/mythen_scans.py
+++ b/src/crystallography_bluesky/i11/plans/mythen_scans.py
@@ -12,7 +12,7 @@ from dodal.utils import get_beamline_name
 from ophyd_async.core import DEFAULT_TIMEOUT, TriggerInfo
 from pydantic import NonNegativeFloat, NonNegativeInt, validate_call
 
-BL = get_beamline_name(os.environ.get("BEAMLINE"))  # type: ignore
+BL = get_beamline_name(os.environ.get("BEAMLINE"))
 
 DEFAULT_MYTHEN: Mythen3 = inject("mythen3")
 DEFAULT_AXIS: Motor = inject("diff_stage.delta")

--- a/src/crystallography_bluesky/i11/plans/mythen_scans.py
+++ b/src/crystallography_bluesky/i11/plans/mythen_scans.py
@@ -2,7 +2,6 @@ import os
 
 import bluesky.plan_stubs as bps
 import bluesky.plans as bsp
-import bluesky.preprocessors as bpp
 import numpy as np
 from bluesky.utils import MsgGenerator
 from dodal.common import inject
@@ -13,7 +12,7 @@ from dodal.utils import get_beamline_name
 from ophyd_async.core import DEFAULT_TIMEOUT, TriggerInfo
 from pydantic import NonNegativeFloat, NonNegativeInt, validate_call
 
-BL = get_beamline_name(os.environ.get("BEAMLINE")) #type: ignore
+BL = get_beamline_name(os.environ.get("BEAMLINE"))  # type: ignore
 
 DEFAULT_MYTHEN: Mythen3 = inject("mythen3")
 DEFAULT_AXIS: Motor = inject("diff_stage.delta")
@@ -32,6 +31,7 @@ def create_steps(
     step_points = list(step_points)
 
     return step_points
+
 
 @validate_call(config={"arbitrary_types_allowed": True})
 # @bpp.run_decorator()  #    # open/close run

--- a/src/crystallography_bluesky/i11/scripts/RJCD_script.py
+++ b/src/crystallography_bluesky/i11/scripts/RJCD_script.py
@@ -1,9 +1,11 @@
-import os, sys
+import os
+import sys
 
 sys.path.append("/dls_sw/i11/software/blueapi/scratch/crystallography-bluesky/src")
 
 import crystallography_bluesky.i11
 from crystallography_bluesky.common.utils.beamline_client import BlueAPIPythonClient
+
 # from crystallography_bluesky.i11.plans import mythen_scan
 
 BL = os.environ["BEAMLINE"]

--- a/src/crystallography_bluesky/i15_1/plans/robot.py
+++ b/src/crystallography_bluesky/i15_1/plans/robot.py
@@ -13,6 +13,8 @@ hutch_interlock = inject("hutch_interlock")
 
 HUTCH_SAFE_FOR_OPERATIONS = 0
 
+robot = inject("robot")
+
 
 def robot_load(
     puck: int,

--- a/src/crystallography_bluesky/i15_1/plans/robot.py
+++ b/src/crystallography_bluesky/i15_1/plans/robot.py
@@ -13,8 +13,6 @@ hutch_interlock = inject("hutch_interlock")
 
 HUTCH_SAFE_FOR_OPERATIONS = 0
 
-robot = inject("robot")
-
 
 def robot_load(
     puck: int,


### PR DESCRIPTION
Updates `beamline_client.py` to use new blueApi client `TaskStatus`.
Moves `inject(...)` out of plan definitions, and some other minor changes to satisfy ruff.
 A by-product of #18 

Fixes currently failing linting.