### PR TITLE
Add `move_hexapod_to_home_position` plan and test

### DIFF
--- a/src/crystallography_bluesky/i15_1/plans/__init__.py
+++ b/src/crystallography_bluesky/i15_1/plans/__init__.py
@@ -1,9 +1,3 @@
-from .robot import (
-    robot_load,
-    robot_unload,
-)
+from .robot import move_hexapod_to_home_position, robot_load, robot_unload
 
-__all__ = [
-    "robot_load",
-    "robot_unload",
-]
+__all__ = ["move_hexapod_to_home_position", "robot_load", "robot_unload"]

--- a/src/crystallography_bluesky/i15_1/plans/robot.py
+++ b/src/crystallography_bluesky/i15_1/plans/robot.py
@@ -14,7 +14,7 @@ robot = inject("robot")
 hutch_interlock = inject("hutch_interlock")
 gonio_interlock = inject("gonio_interlock")
 hexapod = inject("hexapod")
-hexapod_rot = inject("hexapod_rot")
+hexapod_rotation = inject("hexapod_rotation")
 
 HUTCH_SAFE_FOR_OPERATIONS = 0
 GONIO_SAFE_FOR_OPERATIONS = 65535  # All 16 bits are true
@@ -27,7 +27,7 @@ def robot_load(
     hutch_interlock: HutchInterlock = hutch_interlock,
     gonio_interlock: GonioInterlock = gonio_interlock,
     hexapod: XYZStage = hexapod,
-    hexapod_rot: XYZStage = hexapod_rot,
+    hexapod_rotation: XYZStage = hexapod_rotation,
 ) -> MsgGenerator[None]:
     gonio_status = yield from bps.rd(gonio_interlock.is_safe)
     assert gonio_status is True, "Goniometer interlock status was not safe to operate."
@@ -37,7 +37,7 @@ def robot_load(
         "Experimental hutch interlock status was not safe to operate."
     )
 
-    yield from move_hexapod_to_home_position(hexapod, hexapod_rot)
+    yield from move_hexapod_to_home_position(hexapod, hexapod_rotation)
 
     sample = SampleLocation(puck, position)
     yield from bps.abs_set(robot, sample, wait=True)
@@ -48,7 +48,7 @@ def robot_unload(
     hutch_interlock: HutchInterlock = hutch_interlock,
     gonio_interlock: GonioInterlock = gonio_interlock,
     hexapod: XYZStage = hexapod,
-    hexapod_rot: XYZStage = hexapod_rot,
+    hexapod_rotation: XYZStage = hexapod_rotation,
 ) -> MsgGenerator[None]:
     gonio_status = yield from bps.rd(gonio_interlock.is_safe)
     assert gonio_status is True, "Goniometer interlock status was not safe to operate."
@@ -58,14 +58,14 @@ def robot_unload(
         "Experimental hutch interlock status was not safe to operate."
     )
 
-    yield from move_hexapod_to_home_position(hexapod, hexapod_rot)
+    yield from move_hexapod_to_home_position(hexapod, hexapod_rotation)
 
     yield from bps.abs_set(robot, SAMPLE_LOCATION_EMPTY, wait=True)
 
 
 def move_hexapod_to_home_position(
     hexapod: XYZStage = hexapod,
-    hexapod_rot: XYZStage = hexapod_rot,
+    hexapod_rotation: XYZStage = hexapod_rotation,
     x_home: float = 0.0,
     y_home: float = 0.0,
     z_home: float = 0.0,
@@ -77,8 +77,8 @@ def move_hexapod_to_home_position(
     yield from bps.abs_set(hexapod.x, x_home, group=group)
     yield from bps.abs_set(hexapod.y, y_home, group=group)
     yield from bps.abs_set(hexapod.z, z_home, group=group)
-    yield from bps.abs_set(hexapod_rot.x, rx_home, group=group)
-    yield from bps.abs_set(hexapod_rot.y, ry_home, group=group)
-    yield from bps.abs_set(hexapod_rot.z, rz_home, group=group)
+    yield from bps.abs_set(hexapod_rotation.x, rx_home, group=group)
+    yield from bps.abs_set(hexapod_rotation.y, ry_home, group=group)
+    yield from bps.abs_set(hexapod_rotation.z, rz_home, group=group)
 
     yield from bps.wait(group=group)

--- a/src/crystallography_bluesky/i15_1/plans/robot.py
+++ b/src/crystallography_bluesky/i15_1/plans/robot.py
@@ -8,10 +8,13 @@ from dodal.devices.beamlines.i15_1.robot import (
     SampleLocation,
 )
 from dodal.devices.hutch_shutter import HutchInterlock
+from dodal.devices.motors import XYZStage
 
 robot = inject("robot")
 hutch_interlock = inject("hutch_interlock")
 gonio_interlock = inject("gonio_interlock")
+hexapod = inject("hexapod")
+hexapod_rot = inject("hexapod_rot")
 
 HUTCH_SAFE_FOR_OPERATIONS = 0
 GONIO_SAFE_FOR_OPERATIONS = 65535  # All 16 bits are true
@@ -23,6 +26,8 @@ def robot_load(
     robot: Robot = robot,
     hutch_interlock: HutchInterlock = hutch_interlock,
     gonio_interlock: GonioInterlock = gonio_interlock,
+    hexapod: XYZStage = hexapod,
+    hexapod_rot: XYZStage = hexapod_rot,
 ) -> MsgGenerator[None]:
     gonio_status = yield from bps.rd(gonio_interlock.is_safe)
     assert gonio_status is True, "Goniometer interlock status was not safe to operate."
@@ -32,6 +37,8 @@ def robot_load(
         "Experimental hutch interlock status was not safe to operate."
     )
 
+    yield from move_hexapod_to_home_position(hexapod, hexapod_rot, 0, 0, 0, 0, 0, 0)
+
     sample = SampleLocation(puck, position)
     yield from bps.abs_set(robot, sample, wait=True)
 
@@ -40,6 +47,8 @@ def robot_unload(
     robot: Robot = robot,
     hutch_interlock: HutchInterlock = hutch_interlock,
     gonio_interlock: GonioInterlock = gonio_interlock,
+    hexapod: XYZStage = hexapod,
+    hexapod_rot: XYZStage = hexapod_rot,
 ) -> MsgGenerator[None]:
     gonio_status = yield from bps.rd(gonio_interlock.is_safe)
     assert gonio_status is True, "Goniometer interlock status was not safe to operate."
@@ -50,3 +59,24 @@ def robot_unload(
     )
 
     yield from bps.abs_set(robot, SAMPLE_LOCATION_EMPTY, wait=True)
+
+
+def move_hexapod_to_home_position(
+    hexapod: XYZStage = hexapod,
+    hexapod_rot: XYZStage = hexapod_rot,
+    x_home: float = 0.0,
+    y_home: float = 0.0,
+    z_home: float = 0.0,
+    rx_home: float = 0.0,
+    ry_home: float = 0.0,
+    rz_home: float = 0.0,
+    group: str = "hexapod_move_home_group",
+) -> MsgGenerator[None]:
+    yield from bps.abs_set(hexapod.x, x_home, group=group)
+    yield from bps.abs_set(hexapod.y, y_home, group=group)
+    yield from bps.abs_set(hexapod.z, z_home, group=group)
+    yield from bps.abs_set(hexapod_rot.x, rx_home, group=group)
+    yield from bps.abs_set(hexapod_rot.y, ry_home, group=group)
+    yield from bps.abs_set(hexapod_rot.z, rz_home, group=group)
+
+    yield from bps.wait(group=group)

--- a/src/crystallography_bluesky/i15_1/plans/robot.py
+++ b/src/crystallography_bluesky/i15_1/plans/robot.py
@@ -37,7 +37,7 @@ def robot_load(
         "Experimental hutch interlock status was not safe to operate."
     )
 
-    yield from move_hexapod_to_home_position(hexapod, hexapod_rot, 0, 0, 0, 0, 0, 0)
+    yield from move_hexapod_to_home_position(hexapod, hexapod_rot)
 
     sample = SampleLocation(puck, position)
     yield from bps.abs_set(robot, sample, wait=True)
@@ -57,6 +57,8 @@ def robot_unload(
     assert hutch_status is True, (
         "Experimental hutch interlock status was not safe to operate."
     )
+
+    yield from move_hexapod_to_home_position(hexapod, hexapod_rot)
 
     yield from bps.abs_set(robot, SAMPLE_LOCATION_EMPTY, wait=True)
 

--- a/tests/unit_tests/i15_1/test_robot.py
+++ b/tests/unit_tests/i15_1/test_robot.py
@@ -45,10 +45,10 @@ async def hexapod() -> XYZStage:
 
 
 @pytest.fixture
-async def hexapod_rot() -> XYZStage:
+async def hexapod_rotation() -> XYZStage:
     async with init_devices(mock=True):
-        hexapod_rot = XYZStage("", "")
-    return hexapod_rot
+        hexapod_rotation = XYZStage("", "")
+    return hexapod_rotation
 
 
 async def test_plan_loads_robot(
@@ -56,10 +56,14 @@ async def test_plan_loads_robot(
     hutch_interlock: HutchInterlock,
     gonio_interlock: GonioInterlock,
     hexapod: XYZStage,
-    hexapod_rot: XYZStage,
+    hexapod_rotation: XYZStage,
 ):
     RE = RunEngine()
-    RE(robot_load(1, 2, robot, hutch_interlock, gonio_interlock, hexapod, hexapod_rot))
+    RE(
+        robot_load(
+            1, 2, robot, hutch_interlock, gonio_interlock, hexapod, hexapod_rotation
+        )
+    )
 
     assert await robot.puck_sel.get_value() == 1
     assert await robot.pos_sel.get_value() == 2
@@ -70,13 +74,13 @@ async def test_plan_unloads_robot(
     hutch_interlock: HutchInterlock,
     gonio_interlock: GonioInterlock,
     hexapod: XYZStage,
-    hexapod_rot: XYZStage,
+    hexapod_rotation: XYZStage,
 ):
     set_mock_value(robot.current_sample.puck, 1)
     set_mock_value(robot.current_sample.position, 2)
 
     RE = RunEngine()
-    RE(robot_unload(robot, hutch_interlock, gonio_interlock, hexapod, hexapod_rot))
+    RE(robot_unload(robot, hutch_interlock, gonio_interlock, hexapod, hexapod_rotation))
 
     assert await robot.current_sample.puck.get_value() == 0
     assert await robot.current_sample.position.get_value() == 0
@@ -140,7 +144,7 @@ async def test_correct_error_is_raised_when_gonio_is_not_safe_to_operate(
 )
 async def test_plan_moves_hexapod_to_home_position(
     hexapod: XYZStage,
-    hexapod_rot: XYZStage,
+    hexapod_rotation: XYZStage,
     x_home: float,
     y_home: float,
     z_home: float,
@@ -152,7 +156,7 @@ async def test_plan_moves_hexapod_to_home_position(
     RE(
         move_hexapod_to_home_position(
             hexapod=hexapod,
-            hexapod_rot=hexapod_rot,
+            hexapod_rotation=hexapod_rotation,
             x_home=x_home,
             y_home=y_home,
             z_home=z_home,
@@ -165,6 +169,6 @@ async def test_plan_moves_hexapod_to_home_position(
     assert await hexapod.x.user_readback.get_value() == x_home
     assert await hexapod.y.user_readback.get_value() == y_home
     assert await hexapod.z.user_readback.get_value() == z_home
-    assert await hexapod_rot.x.user_readback.get_value() == rx_home
-    assert await hexapod_rot.y.user_readback.get_value() == ry_home
-    assert await hexapod_rot.z.user_readback.get_value() == rz_home
+    assert await hexapod_rotation.x.user_readback.get_value() == rx_home
+    assert await hexapod_rotation.y.user_readback.get_value() == ry_home
+    assert await hexapod_rotation.z.user_readback.get_value() == rz_home

--- a/tests/unit_tests/i15_1/test_robot.py
+++ b/tests/unit_tests/i15_1/test_robot.py
@@ -3,9 +3,14 @@ from bluesky.run_engine import RunEngine
 from dodal.devices.beamlines.i15_1.gonio_interlock import GonioInterlock
 from dodal.devices.beamlines.i15_1.robot import Robot
 from dodal.devices.hutch_shutter import HutchInterlock
+from dodal.devices.motors import XYZStage
 from ophyd_async.core import init_devices, set_mock_value
 
-from crystallography_bluesky.i15_1.plans import robot_load, robot_unload
+from crystallography_bluesky.i15_1.plans import (
+    move_hexapod_to_home_position,
+    robot_load,
+    robot_unload,
+)
 
 
 @pytest.fixture
@@ -32,24 +37,46 @@ async def gonio_interlock() -> GonioInterlock:
     return gonio_interlock
 
 
+@pytest.fixture
+async def hexapod() -> XYZStage:
+    async with init_devices(mock=True):
+        hexapod = XYZStage("", "")
+    return hexapod
+
+
+@pytest.fixture
+async def hexapod_rot() -> XYZStage:
+    async with init_devices(mock=True):
+        hexapod_rot = XYZStage("", "")
+    return hexapod_rot
+
+
 async def test_plan_loads_robot(
-    robot: Robot, hutch_interlock: HutchInterlock, gonio_interlock: GonioInterlock
+    robot: Robot,
+    hutch_interlock: HutchInterlock,
+    gonio_interlock: GonioInterlock,
+    hexapod: XYZStage,
+    hexapod_rot: XYZStage,
 ):
     RE = RunEngine()
-    RE(robot_load(1, 2, robot, hutch_interlock, gonio_interlock))
+    RE(robot_load(1, 2, robot, hutch_interlock, gonio_interlock, hexapod, hexapod_rot))
 
     assert await robot.puck_sel.get_value() == 1
     assert await robot.pos_sel.get_value() == 2
 
 
 async def test_plan_unloads_robot(
-    robot: Robot, hutch_interlock: HutchInterlock, gonio_interlock: GonioInterlock
+    robot: Robot,
+    hutch_interlock: HutchInterlock,
+    gonio_interlock: GonioInterlock,
+    hexapod: XYZStage,
+    hexapod_rot: XYZStage,
 ):
     set_mock_value(robot.current_sample.puck, 1)
     set_mock_value(robot.current_sample.position, 2)
 
     RE = RunEngine()
-    RE(robot_unload(robot, hutch_interlock, gonio_interlock))
+    RE(robot_unload(robot, hutch_interlock, gonio_interlock, hexapod, hexapod_rot))
 
     assert await robot.current_sample.puck.get_value() == 0
     assert await robot.current_sample.position.get_value() == 0
@@ -66,13 +93,19 @@ async def test_correct_error_is_raised_when_hutch_is_not_safe_to_operate(
     robot: Robot,
     hutch_interlock: HutchInterlock,
     gonio_interlock: GonioInterlock,
+    hexapod: XYZStage,
+    hexapod_rot: XYZStage,
     status: int,
     reason: str,
 ):
     set_mock_value(hutch_interlock.status, status)
     RE = RunEngine()
     with pytest.raises(AssertionError, match=reason):
-        RE(robot_load(1, 2, robot, hutch_interlock, gonio_interlock))
+        RE(
+            robot_load(
+                1, 2, robot, hutch_interlock, gonio_interlock, hexapod, hexapod_rot
+            )
+        )
 
 
 @pytest.mark.parametrize(
@@ -86,10 +119,52 @@ async def test_correct_error_is_raised_when_gonio_is_not_safe_to_operate(
     robot: Robot,
     hutch_interlock: HutchInterlock,
     gonio_interlock: GonioInterlock,
+    hexapod: XYZStage,
+    hexapod_rot: XYZStage,
     status: float,
     reason: str,
 ):
     set_mock_value(gonio_interlock.status, status)
     RE = RunEngine()
     with pytest.raises(AssertionError, match=reason):
-        RE(robot_load(1, 2, robot, hutch_interlock, gonio_interlock))
+        RE(
+            robot_load(
+                1, 2, robot, hutch_interlock, gonio_interlock, hexapod, hexapod_rot
+            )
+        )
+
+
+@pytest.mark.parametrize(
+    "x_home, y_home, z_home, rx_home, ry_home, rz_home",
+    ([1, 2, 3, 4, 5, 6], [0, 0, 0, 0, 0, 0]),
+)
+async def test_plan_moves_hexapod_to_home_position(
+    hexapod: XYZStage,
+    hexapod_rot: XYZStage,
+    x_home: float,
+    y_home: float,
+    z_home: float,
+    rx_home: float,
+    ry_home: float,
+    rz_home: float,
+):
+    RE = RunEngine()
+    RE(
+        move_hexapod_to_home_position(
+            hexapod=hexapod,
+            hexapod_rot=hexapod_rot,
+            x_home=x_home,
+            y_home=y_home,
+            z_home=z_home,
+            rx_home=rx_home,
+            ry_home=ry_home,
+            rz_home=rz_home,
+        )
+    )
+
+    assert await hexapod.x.user_readback.get_value() == x_home
+    assert await hexapod.y.user_readback.get_value() == y_home
+    assert await hexapod.z.user_readback.get_value() == z_home
+    assert await hexapod_rot.x.user_readback.get_value() == rx_home
+    assert await hexapod_rot.y.user_readback.get_value() == ry_home
+    assert await hexapod_rot.z.user_readback.get_value() == rz_home

--- a/tests/unit_tests/i15_1/test_robot.py
+++ b/tests/unit_tests/i15_1/test_robot.py
@@ -98,7 +98,7 @@ async def test_correct_error_is_raised_when_hutch_is_not_safe_to_operate(
     hutch_interlock: HutchInterlock,
     gonio_interlock: GonioInterlock,
     hexapod: XYZStage,
-    hexapod_rot: XYZStage,
+    hexapod_rotation: XYZStage,
     status: int,
     reason: str,
 ):
@@ -107,7 +107,7 @@ async def test_correct_error_is_raised_when_hutch_is_not_safe_to_operate(
     with pytest.raises(AssertionError, match=reason):
         RE(
             robot_load(
-                1, 2, robot, hutch_interlock, gonio_interlock, hexapod, hexapod_rot
+                1, 2, robot, hutch_interlock, gonio_interlock, hexapod, hexapod_rotation
             )
         )
 
@@ -124,7 +124,7 @@ async def test_correct_error_is_raised_when_gonio_is_not_safe_to_operate(
     hutch_interlock: HutchInterlock,
     gonio_interlock: GonioInterlock,
     hexapod: XYZStage,
-    hexapod_rot: XYZStage,
+    hexapod_rotation: XYZStage,
     status: float,
     reason: str,
 ):
@@ -133,7 +133,7 @@ async def test_correct_error_is_raised_when_gonio_is_not_safe_to_operate(
     with pytest.raises(AssertionError, match=reason):
         RE(
             robot_load(
-                1, 2, robot, hutch_interlock, gonio_interlock, hexapod, hexapod_rot
+                1, 2, robot, hutch_interlock, gonio_interlock, hexapod, hexapod_rotation
             )
         )
 


### PR DESCRIPTION
Contributes to #9 
Adds a plan to move hexapod to the home position, and moves hexapod to position before robot is loaded/unloaded.