### PR TITLE
Add i15-1_blueapi_config.yaml

### DIFF
--- a/src/crystallography_bluesky/i15_1/i15-1_blueapi_config.yaml
+++ b/src/crystallography_bluesky/i15_1/i15-1_blueapi_config.yaml
@@ -1,0 +1,8 @@
+api:
+  url: https://i15-1-blueapi.diamond.ac.uk
+stomp:
+  auth:
+    username: guest
+    password: guest
+  url: tcp://i15-1-rabbitmq-daq.diamond.ac.uk:61613
+  enabled: true


### PR DESCRIPTION
Closes #36 

Adds `i15-1_blueapi_config.yaml`, which allows easy login for both
* `BlueapiClient`: `bc = BlueapiClient.from_config_file(<path/to/config/file.yaml>)`, and
* `BlueapiCLI`: `blueapi -c <path/to/config/file.yaml> login`