### PR TITLE
Add centre_sample to available plans

### DIFF
--- a/src/crystallography_bluesky/i15_1/plans/__init__.py
+++ b/src/crystallography_bluesky/i15_1/plans/__init__.py
@@ -1,3 +1,4 @@
+from .centre_sample import centre_sample
 from .robot import (
     move_hexapod_to_home_position,
     prepare_beamline_for_robot_load,
@@ -14,4 +15,5 @@ __all__ = [
     "robot_unload",
     "take_snapshot",
     "static_collection",
+    "centre_sample",
 ]


### PR DESCRIPTION
Needed to run the plan on the beamline but also helpful for https://github.com/DiamondLightSource/daq-queuing-service/issues/45