### PR TITLE
I15-1: Add detectors to metadata for nexus writing

### DIFF
--- a/src/crystallography_bluesky/i15_1/plans/generic_collection.py
+++ b/src/crystallography_bluesky/i15_1/plans/generic_collection.py
@@ -79,6 +79,9 @@ def setup_and_teardown_collection(
     )
 
     detectors = [devices.fastcs_eiger, devices.i0]
+    metadata = metadata or {}
+    metadata.update({"detectors": [detector.name for detector in detectors]})
+
     baseline_devices = baseline_devices or []
     LOGGER.info(f"Baseline devices: {baseline_devices}")
 

--- a/tests/unit_tests/i15_1/test_centre_sample.py
+++ b/tests/unit_tests/i15_1/test_centre_sample.py
@@ -89,7 +89,8 @@ def test_centre_sample_plan_makes_expected_calls(
     msgs = assert_message_and_return_remaining(
         msgs,
         predicate=lambda msg: (
-            msg.command == "open_run" and msg.kwargs == {"some": "metadata"}
+            msg.command == "open_run"
+            and msg.kwargs == {"some": "metadata", "detectors": ["fastcs-eiger", "i0"]}
         ),
     )
     msgs = assert_message_and_return_remaining(

--- a/tests/unit_tests/i15_1/test_static_collection.py
+++ b/tests/unit_tests/i15_1/test_static_collection.py
@@ -50,7 +50,8 @@ def test_static_collection_plan_makes_expected_calls(
     msgs = assert_message_and_return_remaining(
         msgs,
         predicate=lambda msg: (
-            msg.command == "open_run" and msg.kwargs == {"some": "metadata"}
+            msg.command == "open_run"
+            and msg.kwargs == {"some": "metadata", "detectors": ["fastcs-eiger", "i0"]}
         ),
     )
     msgs = assert_message_and_return_remaining(


### PR DESCRIPTION
Fixes #67

To test:
* Confirm this matches what's on the beamline and the beamline writes cleaner nexus files